### PR TITLE
Split demo off, update with namespace BLA to avoid naming conflicts

### DIFF
--- a/bash_loading_animations.demo
+++ b/bash_loading_animations.demo
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+source ./bash_loading_animations.sh
+
+demo_interval() { sleep 3 ; kill "${BLA_loading_animation_pid}" &> /dev/null ; echo "$1" ; }
+BLA::start_loading_animation "${BLA_classic[@]}" ; demo_interval BLA_classic
+BLA::start_loading_animation "${BLA_box[@]}" ; demo_interval BLA_box
+BLA::start_loading_animation "${BLA_bubble[@]}" ; demo_interval BLA_bubble
+BLA::start_loading_animation "${BLA_breathe[@]}" ; demo_interval BLA_breathe
+BLA::start_loading_animation "${BLA_growing_dots[@]}" ; demo_interval BLA_growing_dots
+BLA::start_loading_animation "${BLA_passing_dots[@]}" ; demo_interval BLA_passing_dots
+BLA::start_loading_animation "${BLA_metro[@]}" ; demo_interval BLA_metro
+BLA::start_loading_animation "${BLA_classic_utf8[@]}" ; demo_interval BLA_classic_utf8
+BLA::start_loading_animation "${BLA_bounce[@]}" ; demo_interval BLA_bounce
+BLA::start_loading_animation "${BLA_vertical_block[@]}" ; demo_interval BLA_vertical_block
+BLA::start_loading_animation "${BLA_horizontal_block[@]}" ; demo_interval BLA_horizontal_block
+BLA::start_loading_animation "${BLA_quarter[@]}" ; demo_interval BLA_quarter
+BLA::start_loading_animation "${BLA_triangle[@]}" ; demo_interval BLA_triangle
+BLA::start_loading_animation "${BLA_semi_circle[@]}" ; demo_interval BLA_semi_circle
+BLA::start_loading_animation "${BLA_rotating_eyes[@]}" ; demo_interval BLA_rotating_eyes
+BLA::start_loading_animation "${BLA_firework[@]}" ; demo_interval BLA_firework
+BLA::start_loading_animation "${BLA_braille[@]}" ; demo_interval BLA_braille
+BLA::start_loading_animation "${BLA_braille_whitespace[@]}" ; demo_interval BLA_braille_whitespace
+BLA::start_loading_animation "${BLA_trigram[@]}" ; demo_interval BLA_trigram
+BLA::start_loading_animation "${BLA_arrow[@]}" ; demo_interval BLA_arrow
+BLA::start_loading_animation "${BLA_bouncing_ball[@]}" ; demo_interval BLA_bouncing_ball
+BLA::start_loading_animation "${BLA_big_dot[@]}" ; demo_interval BLA_big_dot
+BLA::start_loading_animation "${BLA_modern_metro[@]}" ; demo_interval BLA_modern_metro
+BLA::start_loading_animation "${BLA_pong[@]}" ; demo_interval BLA_pong
+BLA::start_loading_animation "${BLA_clock[@]}" ; demo_interval BLA_clock
+BLA::start_loading_animation "${BLA_moon[@]}" ; demo_interval BLA_moon
+BLA::start_loading_animation "${BLA_orange_pulse[@]}" ; demo_interval BLA_orange_pulse
+BLA::start_loading_animation "${BLA_blue_pulse[@]}" ; demo_interval BLA_blue_pulse
+BLA::start_loading_animation "${BLA_football[@]}" ; demo_interval BLA_football
+BLA::start_loading_animation "${BLA_blink[@]}" ; demo_interval BLA_blink
+BLA::start_loading_animation "${BLA_camera[@]}" ; demo_interval BLA_camera
+BLA::start_loading_animation "${BLA_sparkling_camera[@]}" ; demo_interval BLA_sparkling_camera
+BLA::start_loading_animation "${BLA_sick[@]}" ; demo_interval BLA_sick
+BLA::start_loading_animation "${BLA_monkey[@]}" ; demo_interval BLA_monkey
+BLA::start_loading_animation "${BLA_bomb[@]}" ; demo_interval BLA_bomb
+exit 0

--- a/bash_loading_animations.demo
+++ b/bash_loading_animations.demo
@@ -4,7 +4,7 @@ source ./bash_loading_animations.sh
 
 # We sleep long enough that all the characters for each animation are
 # displayed.
-demo_interval() { s=$(echo "$2 * ($3-1)" | bc); sleep "$s" ; kill "${BLA_loading_animation_pid}" &> /dev/null ; echo "$1" ; set +x; }
+demo_interval() { s=$(echo "$2 * ($3-1)" | bc); sleep "$s" ; kill "${BLA_loading_animation_pid}" &> /dev/null ; echo "$1" ; }
 
 BLA::start_loading_animation "${BLA_classic[@]}" ; demo_interval BLA_classic "${BLA_classic[0]}" "${#BLA_classic[@]}"
 BLA::start_loading_animation "${BLA_box[@]}" ; demo_interval BLA_box "${BLA_box[0]}" "${#BLA_box[@]}"

--- a/bash_loading_animations.demo
+++ b/bash_loading_animations.demo
@@ -3,7 +3,8 @@
 source ./bash_loading_animations.sh
 
 # We sleep long enough that all the characters for each animation are
-# displayed.
+# displayed.  We subtract 1 because the array is one longer than the number of
+# animations, due to the interval at [0].
 demo_interval() { s=$(echo "$2 * ($3-1)" | bc); sleep "$s" ; kill "${BLA_loading_animation_pid}" &> /dev/null ; echo "$1" ; }
 
 BLA::start_loading_animation "${BLA_classic[@]}" ; demo_interval BLA_classic "${BLA_classic[0]}" "${#BLA_classic[@]}"

--- a/bash_loading_animations.demo
+++ b/bash_loading_animations.demo
@@ -3,8 +3,7 @@
 source ./bash_loading_animations.sh
 
 # We sleep long enough that all the characters for each animation are
-# displayed.  We subtract 1 because the array is one longer than the number of
-# animations, due to the interval at [0].
+# displayed.
 demo_interval() { s=$(echo "$2 * ($3-1)" | bc); sleep "$s" ; kill "${BLA_loading_animation_pid}" &> /dev/null ; echo "$1" ; set +x; }
 
 BLA::start_loading_animation "${BLA_classic[@]}" ; demo_interval BLA_classic "${BLA_classic[0]}" "${#BLA_classic[@]}"

--- a/bash_loading_animations.demo
+++ b/bash_loading_animations.demo
@@ -32,6 +32,7 @@ BLA::start_loading_animation "${BLA_big_dot[@]}" ; demo_interval BLA_big_dot "${
 BLA::start_loading_animation "${BLA_modern_metro[@]}" ; demo_interval BLA_modern_metro "${BLA_modern_metro[0]}" "${#BLA_modern_metro[@]}"
 BLA::start_loading_animation "${BLA_pong[@]}" ; demo_interval BLA_pong "${BLA_pong[0]}" "${#BLA_pong[@]}"
 BLA::start_loading_animation "${BLA_clock[@]}" ; demo_interval BLA_clock "${BLA_clock[0]}" "${#BLA_clock[@]}"
+BLA::start_loading_animation "${BLA_earth[@]}" ; demo_interval BLA_earth "${BLA_earth[0]}" "${#BLA_earth[@]}"
 BLA::start_loading_animation "${BLA_moon[@]}" ; demo_interval BLA_moon "${BLA_moon[0]}" "${#BLA_moon[@]}"
 BLA::start_loading_animation "${BLA_orange_pulse[@]}" ; demo_interval BLA_orange_pulse "${BLA_orange_pulse[0]}" "${#BLA_orange_pulse[@]}"
 BLA::start_loading_animation "${BLA_blue_pulse[@]}" ; demo_interval BLA_blue_pulse "${BLA_blue_pulse[0]}" "${#BLA_blue_pulse[@]}"

--- a/bash_loading_animations.demo
+++ b/bash_loading_animations.demo
@@ -2,40 +2,44 @@
 
 source ./bash_loading_animations.sh
 
-demo_interval() { sleep 3 ; kill "${BLA_loading_animation_pid}" &> /dev/null ; echo "$1" ; }
-BLA::start_loading_animation "${BLA_classic[@]}" ; demo_interval BLA_classic
-BLA::start_loading_animation "${BLA_box[@]}" ; demo_interval BLA_box
-BLA::start_loading_animation "${BLA_bubble[@]}" ; demo_interval BLA_bubble
-BLA::start_loading_animation "${BLA_breathe[@]}" ; demo_interval BLA_breathe
-BLA::start_loading_animation "${BLA_growing_dots[@]}" ; demo_interval BLA_growing_dots
-BLA::start_loading_animation "${BLA_passing_dots[@]}" ; demo_interval BLA_passing_dots
-BLA::start_loading_animation "${BLA_metro[@]}" ; demo_interval BLA_metro
-BLA::start_loading_animation "${BLA_classic_utf8[@]}" ; demo_interval BLA_classic_utf8
-BLA::start_loading_animation "${BLA_bounce[@]}" ; demo_interval BLA_bounce
-BLA::start_loading_animation "${BLA_vertical_block[@]}" ; demo_interval BLA_vertical_block
-BLA::start_loading_animation "${BLA_horizontal_block[@]}" ; demo_interval BLA_horizontal_block
-BLA::start_loading_animation "${BLA_quarter[@]}" ; demo_interval BLA_quarter
-BLA::start_loading_animation "${BLA_triangle[@]}" ; demo_interval BLA_triangle
-BLA::start_loading_animation "${BLA_semi_circle[@]}" ; demo_interval BLA_semi_circle
-BLA::start_loading_animation "${BLA_rotating_eyes[@]}" ; demo_interval BLA_rotating_eyes
-BLA::start_loading_animation "${BLA_firework[@]}" ; demo_interval BLA_firework
-BLA::start_loading_animation "${BLA_braille[@]}" ; demo_interval BLA_braille
-BLA::start_loading_animation "${BLA_braille_whitespace[@]}" ; demo_interval BLA_braille_whitespace
-BLA::start_loading_animation "${BLA_trigram[@]}" ; demo_interval BLA_trigram
-BLA::start_loading_animation "${BLA_arrow[@]}" ; demo_interval BLA_arrow
-BLA::start_loading_animation "${BLA_bouncing_ball[@]}" ; demo_interval BLA_bouncing_ball
-BLA::start_loading_animation "${BLA_big_dot[@]}" ; demo_interval BLA_big_dot
-BLA::start_loading_animation "${BLA_modern_metro[@]}" ; demo_interval BLA_modern_metro
-BLA::start_loading_animation "${BLA_pong[@]}" ; demo_interval BLA_pong
-BLA::start_loading_animation "${BLA_clock[@]}" ; demo_interval BLA_clock
-BLA::start_loading_animation "${BLA_moon[@]}" ; demo_interval BLA_moon
-BLA::start_loading_animation "${BLA_orange_pulse[@]}" ; demo_interval BLA_orange_pulse
-BLA::start_loading_animation "${BLA_blue_pulse[@]}" ; demo_interval BLA_blue_pulse
-BLA::start_loading_animation "${BLA_football[@]}" ; demo_interval BLA_football
-BLA::start_loading_animation "${BLA_blink[@]}" ; demo_interval BLA_blink
-BLA::start_loading_animation "${BLA_camera[@]}" ; demo_interval BLA_camera
-BLA::start_loading_animation "${BLA_sparkling_camera[@]}" ; demo_interval BLA_sparkling_camera
-BLA::start_loading_animation "${BLA_sick[@]}" ; demo_interval BLA_sick
-BLA::start_loading_animation "${BLA_monkey[@]}" ; demo_interval BLA_monkey
-BLA::start_loading_animation "${BLA_bomb[@]}" ; demo_interval BLA_bomb
+# We sleep logn enough that all the characters for each animation are displayed
+# and we get back to char 1, because the array is one longer than the number of
+# animations, due to the interval at [0].
+demo_interval() { s=$(echo "$2 * $3" | bc); sleep "$s" ; kill "${BLA_loading_animation_pid}" &> /dev/null ; echo "$1" ; set +x; }
+
+BLA::start_loading_animation "${BLA_classic[@]}" ; demo_interval BLA_classic "${BLA_classic[0]}" "${#BLA_classic[@]}"
+BLA::start_loading_animation "${BLA_box[@]}" ; demo_interval BLA_box "${BLA_box[0]}" "${#BLA_box[@]}"
+BLA::start_loading_animation "${BLA_bubble[@]}" ; demo_interval BLA_bubble "${BLA_bubble[0]}" "${#BLA_bubble[@]}"
+BLA::start_loading_animation "${BLA_breathe[@]}" ; demo_interval BLA_breathe "${BLA_breathe[0]}" "${#BLA_breathe[@]}"
+BLA::start_loading_animation "${BLA_growing_dots[@]}" ; demo_interval BLA_growing_dots "${BLA_growing_dots[0]}" "${#BLA_growing_dots[@]}"
+BLA::start_loading_animation "${BLA_passing_dots[@]}" ; demo_interval BLA_passing_dots "${BLA_passing_dots[0]}" "${#BLA_passing_dots[@]}"
+BLA::start_loading_animation "${BLA_metro[@]}" ; demo_interval BLA_metro "${BLA_metro[0]}" "${#BLA_metro[@]}"
+BLA::start_loading_animation "${BLA_classic_utf8[@]}" ; demo_interval BLA_classic_utf8 "${BLA_classic_utf8[0]}" "${#BLA_classic_utf8[@]}"
+BLA::start_loading_animation "${BLA_bounce[@]}" ; demo_interval BLA_bounce "${BLA_bounce[0]}" "${#BLA_bounce[@]}"
+BLA::start_loading_animation "${BLA_vertical_block[@]}" ; demo_interval BLA_vertical_block "${BLA_vertical_block[0]}" "${#BLA_vertical_block[@]}"
+BLA::start_loading_animation "${BLA_horizontal_block[@]}" ; demo_interval BLA_horizontal_block "${BLA_horizontal_block[0]}" "${#BLA_horizontal_block[@]}"
+BLA::start_loading_animation "${BLA_quarter[@]}" ; demo_interval BLA_quarter "${BLA_quarter[0]}" "${#BLA_quarter[@]}"
+BLA::start_loading_animation "${BLA_triangle[@]}" ; demo_interval BLA_triangle "${BLA_triangle[0]}" "${#BLA_triangle[@]}"
+BLA::start_loading_animation "${BLA_semi_circle[@]}" ; demo_interval BLA_semi_circle "${BLA_semi_circle[0]}" "${#BLA_semi_circle[@]}"
+BLA::start_loading_animation "${BLA_rotating_eyes[@]}" ; demo_interval BLA_rotating_eyes "${BLA_rotating_eyes[0]}" "${#BLA_rotating_eyes[@]}"
+BLA::start_loading_animation "${BLA_firework[@]}" ; demo_interval BLA_firework "${BLA_firework[0]}" "${#BLA_firework[@]}"
+BLA::start_loading_animation "${BLA_braille[@]}" ; demo_interval BLA_braille "${BLA_braille[0]}" "${#BLA_braille[@]}"
+BLA::start_loading_animation "${BLA_braille_whitespace[@]}" ; demo_interval BLA_braille_whitespace "${BLA_braille_whitespace[0]}" "${#BLA_braille_whitespace[@]}"
+BLA::start_loading_animation "${BLA_trigram[@]}" ; demo_interval BLA_trigram "${BLA_trigram[0]}" "${#BLA_trigram[@]}"
+BLA::start_loading_animation "${BLA_arrow[@]}" ; demo_interval BLA_arrow "${BLA_arrow[0]}" "${#BLA_arrow[@]}"
+BLA::start_loading_animation "${BLA_bouncing_ball[@]}" ; demo_interval BLA_bouncing_ball "${BLA_bouncing_ball[0]}" "${#BLA_bouncing_ball[@]}"
+BLA::start_loading_animation "${BLA_big_dot[@]}" ; demo_interval BLA_big_dot "${BLA_big_dot[0]}" "${#BLA_big_dot[@]}"
+BLA::start_loading_animation "${BLA_modern_metro[@]}" ; demo_interval BLA_modern_metro "${BLA_modern_metro[0]}" "${#BLA_modern_metro[@]}"
+BLA::start_loading_animation "${BLA_pong[@]}" ; demo_interval BLA_pong "${BLA_pong[0]}" "${#BLA_pong[@]}"
+BLA::start_loading_animation "${BLA_clock[@]}" ; demo_interval BLA_clock "${BLA_clock[0]}" "${#BLA_clock[@]}"
+BLA::start_loading_animation "${BLA_moon[@]}" ; demo_interval BLA_moon "${BLA_moon[0]}" "${#BLA_moon[@]}"
+BLA::start_loading_animation "${BLA_orange_pulse[@]}" ; demo_interval BLA_orange_pulse "${BLA_orange_pulse[0]}" "${#BLA_orange_pulse[@]}"
+BLA::start_loading_animation "${BLA_blue_pulse[@]}" ; demo_interval BLA_blue_pulse "${BLA_blue_pulse[0]}" "${#BLA_blue_pulse[@]}"
+BLA::start_loading_animation "${BLA_football[@]}" ; demo_interval BLA_football "${BLA_football[0]}" "${#BLA_football[@]}"
+BLA::start_loading_animation "${BLA_blink[@]}" ; demo_interval BLA_blink "${BLA_blink[0]}" "${#BLA_blink[@]}"
+BLA::start_loading_animation "${BLA_camera[@]}" ; demo_interval BLA_camera "${BLA_camera[0]}" "${#BLA_camera[@]}"
+BLA::start_loading_animation "${BLA_sparkling_camera[@]}" ; demo_interval BLA_sparkling_camera "${BLA_sparkling_camera[0]}" "${#BLA_sparkling_camera[@]}"
+BLA::start_loading_animation "${BLA_sick[@]}" ; demo_interval BLA_sick "${BLA_sick[0]}" "${#BLA_sick[@]}"
+BLA::start_loading_animation "${BLA_monkey[@]}" ; demo_interval BLA_monkey "${BLA_monkey[0]}" "${#BLA_monkey[@]}"
+BLA::start_loading_animation "${BLA_bomb[@]}" ; demo_interval BLA_bomb "${BLA_bomb[0]}" "${#BLA_bomb[@]}"
 exit 0

--- a/bash_loading_animations.demo
+++ b/bash_loading_animations.demo
@@ -2,10 +2,10 @@
 
 source ./bash_loading_animations.sh
 
-# We sleep logn enough that all the characters for each animation are displayed
-# and we get back to char 1, because the array is one longer than the number of
+# We sleep long enough that all the characters for each animation are
+# displayed.  We subtract 1 because the array is one longer than the number of
 # animations, due to the interval at [0].
-demo_interval() { s=$(echo "$2 * $3" | bc); sleep "$s" ; kill "${BLA_loading_animation_pid}" &> /dev/null ; echo "$1" ; set +x; }
+demo_interval() { s=$(echo "$2 * ($3-1)" | bc); sleep "$s" ; kill "${BLA_loading_animation_pid}" &> /dev/null ; echo "$1" ; set +x; }
 
 BLA::start_loading_animation "${BLA_classic[@]}" ; demo_interval BLA_classic "${BLA_classic[0]}" "${#BLA_classic[@]}"
 BLA::start_loading_animation "${BLA_box[@]}" ; demo_interval BLA_box "${BLA_box[0]}" "${#BLA_box[@]}"

--- a/bash_loading_animations.sh
+++ b/bash_loading_animations.sh
@@ -1,145 +1,86 @@
 #!/usr/bin/env bash
 
-##### Table of contents #####
-# 1. Loading animations list
-# 2. Main code
-# 3. Demo the animations
-# 4. Usage guide
-# 5. Compact versions of the main code
-
-###################################### 1 ######################################
-############# COPY THE ANIMATIONS BELOW TO THE TOP OF YOUR SCRIPT #############
-###############################################################################
-################### You can safely remove the lines for the ###################
-#################### animations you are not interested in. ####################
-###############################################################################
-
 ### Loading animations list
 # The first value of an array is the interval (in seconds) between each frame
 
+# shellcheck disable=SC2034 #https://github.com/koalaman/shellcheck/wiki/SC2034
+
 ## ASCII animations ##
 # Will work in any terminal, including the TTY.
-classic=( 0.25 '-' '\' '|' '/' )
-box=( 0.2 ┤ ┴ ├ ┬ )
-bubble=( 0.6 · o O O o · )
-breathe=( 0.9 '  ()  ' ' (  ) ' '(    )' ' (  ) ' )
-growing_dots=( 0.5 '.  ' '.. ' '...' '.. ' '.  ' '   ' )
-passing_dots=( 0.25 '.  ' '.. ' '...' ' ..' '  .' '   ' )
-metro=( 0.2 '[    ]' '[=   ]' '[==  ]' '[=== ]' '[ ===]' '[  ==]' '[   =]' )
+declare BLA_classic=( 0.25 '-' "\\" '|' '/' )
+declare BLA_box=( 0.2 ┤ ┴ ├ ┬ )
+declare BLA_bubble=( 0.6 · o O O o · )
+declare BLA_breathe=( 0.9 '  ()  ' ' (  ) ' '(    )' ' (  ) ' )
+declare BLA_growing_dots=( 0.5 '.  ' '.. ' '...' '.. ' '.  ' '   ' )
+declare BLA_passing_dots=( 0.25 '.  ' '.. ' '...' ' ..' '  .' '   ' )
+declare BLA_metro=( 0.2 '[    ]' '[=   ]' '[==  ]' '[=== ]' '[ ===]' '[  ==]' '[   =]' )
 
 ## UTF-8 animations ##
 # Require Unicode support (will work in most modern terminals, but not in TTY).
 # Some animations may not render properly with certain fonts.
-classic_utf8=( 0.25 '—' '\' '|' '/' )
-bounce=( 0.3 . · ˙ · )
-vertical_block=( 0.25 ▁ ▂ ▃ ▄ ▅ ▆ ▇ █ █ ▇ ▆ ▅ ▄ ▃ ▁ )
-horizontal_block=( 0.25 ▏ ▎ ▍ ▌ ▋ ▊ ▉ ▉ ▊ ▋ ▌ ▍ ▎ ▏ )
-quarter=( 0.25 ▖ ▘ ▝ ▗ )
-triangle=( 0.45 ◢ ◣ ◤ ◥)
-semi_circle=( 0.1 ◐ ◓ ◑ ◒ )
-rotating_eyes=( 0.4 ◡◡ ⊙⊙ ⊙⊙ ◠◠ )
-firework=( 0.4 '⢀' '⠠' '⠐' '⠈' '*' '*' ' ' )
-braille=( 0.2 ⠁ ⠂ ⠄ ⡀ ⢀ ⠠ ⠐ ⠈ )
-braille_whitespace=( 0.2 ⣾ ⣽ ⣻ ⢿ ⡿ ⣟ ⣯ ⣷ )
-trigram=( 0.25 ☰ ☱ ☳ ☶ ☴ )
-arrow=( 0.15 ▹▹▹▹▹ ▸▹▹▹▹ ▹▸▹▹▹ ▹▹▸▹▹ ▹▹▹▸▹ ▹▹▹▹▸ ▹▹▹▹▹ ▹▹▹▹▹ ▹▹▹▹▹ ▹▹▹▹▹ ▹▹▹▹▹ ▹▹▹▹▹ ▹▹▹▹▹ )
-bouncing_ball=( 0.4 '(●     )' '( ●    )' '(  ●   )' '(   ●  )' '(    ● )' '(     ●)' '(    ● )' '(   ●  )' '(  ●   )' '( ●    )' )
-big_dot=( 0.7 ∙∙∙ ●∙∙ ∙●∙ ∙∙● )
-modern_metro=( 0.15 ▰▱▱▱▱▱▱ ▰▰▱▱▱▱▱ ▰▰▰▱▱▱▱ ▱▰▰▰▱▱▱ ▱▱▰▰▰▱▱ ▱▱▱▰▰▰▱ ▱▱▱▱▰▰▰ ▱▱▱▱▱▰▰ ▱▱▱▱▱▱▰ ▱▱▱▱▱▱▱ ▱▱▱▱▱▱▱ ▱▱▱▱▱▱▱ ▱▱▱▱▱▱▱ )
-pong=( 0.35 '▐⠂       ▌' '▐⠈       ▌' '▐ ⠂      ▌' '▐ ⠠      ▌' '▐  ⡀     ▌' '▐  ⠠     ▌' '▐   ⠂    ▌' '▐   ⠈    ▌' '▐    ⠂   ▌' '▐    ⠠   ▌' '▐     ⡀  ▌' '▐     ⠠  ▌' '▐      ⠂ ▌' '▐      ⠈ ▌' '▐       ⠂▌' '▐       ⠠▌' '▐       ⡀▌' '▐      ⠠ ▌' '▐      ⠂ ▌' '▐     ⠈  ▌' '▐     ⠂  ▌' '▐    ⠠   ▌' '▐    ⡀   ▌' '▐   ⠠    ▌' '▐   ⠂    ▌' '▐  ⠈     ▌' '▐  ⠂     ▌' '▐ ⠠      ▌' '▐ ⡀      ▌' '▐⠠       ▌' )
-earth=( 0.45 🌍 🌎 🌏 )
-clock=( 0.2 🕛 🕐 🕑 🕒 🕓 🕔 🕕 🕖 🕗 🕘 🕙 🕚 )
-moon=( 0.8 🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 )
-orange_pulse=( 0.35 🔸 🔶 🟠 🟠 🔶 )
-blue_pulse=( 0.35 🔹 🔷 🔵 🔵 🔷 )
-football=( 0.25 ' 👧⚽️       👦' '👧  ⚽️      👦' '👧   ⚽️     👦' '👧    ⚽️    👦' '👧     ⚽️   👦' '👧      ⚽️  👦' '👧       ⚽️👦 ' '👧      ⚽️  👦' '👧     ⚽️   👦' '👧    ⚽️    👦' '👧   ⚽️     👦' '👧  ⚽️      👦' )
-blink=( 0.25 😐 😐 😐 😐 😐 😐 😐 😐 😐 😑 )
-camera=( 0.1 📷 📷 📷 📷 📷 📷 📷 📷 📷 📷 📷 📷 📷 📷 📷 📷 📷 📷 📷 📷 📸 📷 📸 )
-sparkling_camera=( 0.1 '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📸✨' '📷 ' '📸✨' )
-sick=( 0.9 🤢 🤢 🤮 )
-monkey=( 0.4 🙉 🙈 🙊 🙈 )
-bomb=( 0.25 '💣   ' ' 💣  ' '  💣 ' '   💣' '   💣' '   💣' '   💣' '   💣' '   💥' '    ' '    ' )
+declare BLA_classic_utf8=( 0.25 '—' "\\" '|' '/' )
+declare BLA_bounce=( 0.3 . · ˙ · )
+declare BLA_vertical_block=( 0.25 ▁ ▂ ▃ ▄ ▅ ▆ ▇ █ █ ▇ ▆ ▅ ▄ ▃ ▁ )
+declare BLA_horizontal_block=( 0.25 ▏ ▎ ▍ ▌ ▋ ▊ ▉ ▉ ▊ ▋ ▌ ▍ ▎ ▏ )
+declare BLA_quarter=( 0.25 ▖ ▘ ▝ ▗ )
+declare BLA_triangle=( 0.45 ◢ ◣ ◤ ◥)
+declare BLA_semi_circle=( 0.1 ◐ ◓ ◑ ◒ )
+declare BLA_rotating_eyes=( 0.4 ◡◡ ⊙⊙ ⊙⊙ ◠◠ )
+declare BLA_firework=( 0.4 '⢀' '⠠' '⠐' '⠈' '*' '*' ' ' )
+declare BLA_braille=( 0.2 ⠁ ⠂ ⠄ ⡀ ⢀ ⠠ ⠐ ⠈ )
+declare BLA_braille_whitespace=( 0.2 ⣾ ⣽ ⣻ ⢿ ⡿ ⣟ ⣯ ⣷ )
+declare BLA_trigram=( 0.25 ☰ ☱ ☳ ☶ ☴ )
+declare BLA_arrow=( 0.15 ▹▹▹▹▹ ▸▹▹▹▹ ▹▸▹▹▹ ▹▹▸▹▹ ▹▹▹▸▹ ▹▹▹▹▸ ▹▹▹▹▹ ▹▹▹▹▹ ▹▹▹▹▹ ▹▹▹▹▹ ▹▹▹▹▹ ▹▹▹▹▹ ▹▹▹▹▹ )
+declare BLA_bouncing_ball=( 0.4 '(●     )' '( ●    )' '(  ●   )' '(   ●  )' '(    ● )' '(     ●)' '(    ● )' '(   ●  )' '(  ●   )' '( ●    )' )
+declare BLA_big_dot=( 0.7 ∙∙∙ ●∙∙ ∙●∙ ∙∙● )
+declare BLA_modern_metro=( 0.15 ▰▱▱▱▱▱▱ ▰▰▱▱▱▱▱ ▰▰▰▱▱▱▱ ▱▰▰▰▱▱▱ ▱▱▰▰▰▱▱ ▱▱▱▰▰▰▱ ▱▱▱▱▰▰▰ ▱▱▱▱▱▰▰ ▱▱▱▱▱▱▰ ▱▱▱▱▱▱▱ ▱▱▱▱▱▱▱ ▱▱▱▱▱▱▱ ▱▱▱▱▱▱▱ )
+declare BLA_pong=( 0.35 '▐⠂       ▌' '▐⠈       ▌' '▐ ⠂      ▌' '▐ ⠠      ▌' '▐  ⡀     ▌' '▐  ⠠     ▌' '▐   ⠂    ▌' '▐   ⠈    ▌' '▐    ⠂   ▌' '▐    ⠠   ▌' '▐     ⡀  ▌' '▐     ⠠  ▌' '▐      ⠂ ▌' '▐      ⠈ ▌' '▐       ⠂▌' '▐       ⠠▌' '▐       ⡀▌' '▐      ⠠ ▌' '▐      ⠂ ▌' '▐     ⠈  ▌' '▐     ⠂  ▌' '▐    ⠠   ▌' '▐    ⡀   ▌' '▐   ⠠    ▌' '▐   ⠂    ▌' '▐  ⠈     ▌' '▐  ⠂     ▌' '▐ ⠠      ▌' '▐ ⡀      ▌' '▐⠠       ▌' )
+declare BLA_earth=( 0.45 🌍 🌎 🌏 )
+declare BLA_clock=( 0.2 🕛 🕐 🕑 🕒 🕓 🕔 🕕 🕖 🕗 🕘 🕙 🕚 )
+declare BLA_moon=( 0.8 🌑 🌒 🌓 🌔 🌕 🌖 🌗 🌘 )
+declare BLA_orange_pulse=( 0.35 🔸 🔶 🟠 🟠 🔶 )
+declare BLA_blue_pulse=( 0.35 🔹 🔷 🔵 🔵 🔷 )
+declare BLA_football=( 0.25 ' 👧⚽️       👦' '👧  ⚽️      👦' '👧   ⚽️     👦' '👧    ⚽️    👦' '👧     ⚽️   👦' '👧      ⚽️  👦' '👧       ⚽️👦 ' '👧      ⚽️  👦' '👧     ⚽️   👦' '👧    ⚽️    👦' '👧   ⚽️     👦' '👧  ⚽️      👦' )
+declare BLA_blink=( 0.25 😐 😐 😐 😐 😐 😐 😐 😐 😐 😑 )
+declare BLA_camera=( 0.1 📷 📷 📷 📷 📷 📷 📷 📷 📷 📷 📷 📷 📷 📷 📷 📷 📷 📷 📷 📷 📸 📷 📸 )
+declare BLA_sparkling_camera=( 0.1 '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📷 ' '📸✨' '📷 ' '📸✨' )
+declare BLA_sick=( 0.9 🤢 🤢 🤮 )
+declare BLA_monkey=( 0.4 🙉 🙈 🙊 🙈 )
+declare BLA_bomb=( 0.25 '💣   ' ' 💣  ' '  💣 ' '   💣' '   💣' '   💣' '   💣' '   💣' '   💥' '    ' '    ' )
 
-###################################### 2 ######################################
-##### COPY THE CODE BELOW IN YOUR SCRIPT, RIGHT AFTER THE ANIMATIONS LIST #####
-###############################################################################
-############## If you would prefer to use a more compact version ##############
-################# of this code, go to the bottom of the file. #################
-###############################################################################
+declare -a BLA_active_loading_animation
+declare BLA_loading_animation_frame_interval
+declare BLA_loading_animation_pid
 
 # Run stop_loading_animation if the script is interrupted
-trap stop_loading_animation SIGINT
+trap BLA::stop_loading_animation SIGINT
 
-play_loading_animation_loop() {
+BLA::play_loading_animation_loop() {
+  declare frame
   while true ; do
-    for frame in "${active_loading_animation[@]}" ; do
+    for frame in "${BLA_active_loading_animation[@]}" ; do
       printf "\r%s" "${frame}"
-      sleep "${loading_animation_frame_interval}"
+      sleep "${BLA_loading_animation_frame_interval}"
     done
   done
 }
 
-start_loading_animation() {
-  active_loading_animation=( "${@}" )
+BLA::start_loading_animation() {
+  BLA_active_loading_animation=( "${@}" )
   # Extract the delay between each frame from the active_loading_animation array
-  loading_animation_frame_interval="${active_loading_animation[0]}"
-  unset "active_loading_animation[0]"
+  BLA_loading_animation_frame_interval="${BLA_active_loading_animation[0]}"
+  unset "BLA_active_loading_animation[0]"
   tput civis # Hide the terminal cursor
-  play_loading_animation_loop &
-  loading_animation_pid="${!}"
+  BLA::play_loading_animation_loop &
+  BLA_loading_animation_pid="${!}"
 }
 
-stop_loading_animation() {
-  kill "${loading_animation_pid}" &> /dev/null
+BLA::stop_loading_animation() {
+  kill "${BLA_loading_animation_pid}" &> /dev/null
   printf "\n"
   tput cnorm # Restore the terminal cursor
 }
 
-###################################### 3 ######################################
-######################### DEMO THE LOADING ANIMATIONS #########################
-###############################################################################
-########## The code below serves as a way to preview the animations. ##########
-################ You do not need to include it in your script. ################
-###############################################################################
-
-demo_interval() { sleep 7 ; kill "${loading_animation_pid}" &> /dev/null ; printf "\r                    \r" ; }
-start_loading_animation "${classic[@]}" ; demo_interval
-start_loading_animation "${box[@]}" ; demo_interval
-start_loading_animation "${bubble[@]}" ; demo_interval
-start_loading_animation "${breathe[@]}" ; demo_interval
-start_loading_animation "${growing_dots[@]}" ; demo_interval
-start_loading_animation "${passing_dots[@]}" ; demo_interval
-start_loading_animation "${metro[@]}" ; demo_interval
-start_loading_animation "${classic_utf8[@]}" ; demo_interval
-start_loading_animation "${bounce[@]}" ; demo_interval
-start_loading_animation "${vertical_block[@]}" ; demo_interval
-start_loading_animation "${horizontal_block[@]}" ; demo_interval
-start_loading_animation "${quarter[@]}" ; demo_interval
-start_loading_animation "${triangle[@]}" ; demo_interval
-start_loading_animation "${semi_circle[@]}" ; demo_interval
-start_loading_animation "${rotating_eyes[@]}" ; demo_interval
-start_loading_animation "${firework[@]}" ; demo_interval
-start_loading_animation "${braille[@]}" ; demo_interval
-start_loading_animation "${braille_whitespace[@]}" ; demo_interval
-start_loading_animation "${trigram[@]}" ; demo_interval
-start_loading_animation "${arrow[@]}" ; demo_interval
-start_loading_animation "${bouncing_ball[@]}" ; demo_interval
-start_loading_animation "${big_dot[@]}" ; demo_interval
-start_loading_animation "${modern_metro[@]}" ; demo_interval
-start_loading_animation "${pong[@]}" ; demo_interval
-start_loading_animation "${earth[@]}" ; demo_interval
-start_loading_animation "${clock[@]}" ; demo_interval
-start_loading_animation "${moon[@]}" ; demo_interval
-start_loading_animation "${orange_pulse[@]}" ; demo_interval
-start_loading_animation "${blue_pulse[@]}" ; demo_interval
-start_loading_animation "${football[@]}" ; demo_interval
-start_loading_animation "${blink[@]}" ; demo_interval
-start_loading_animation "${camera[@]}" ; demo_interval
-start_loading_animation "${sparkling_camera[@]}" ; demo_interval
-start_loading_animation "${sick[@]}" ; demo_interval
-start_loading_animation "${monkey[@]}" ; demo_interval
-start_loading_animation "${bomb[@]}" ; demo_interval
-exit 0
 
 ###################################### 4 ######################################
 ################################# USAGE GUIDE #################################
@@ -148,40 +89,22 @@ exit 0
 ################### show loading animations in your script. ###################
 ###############################################################################
 
-# Show a loading animation for the command "foo"
-start_loading_animation "${name_of_the_animation[@]}"
-foo
-stop_loading_animation
+:<<'EXAMPLES'
 
-# If the command prints some output in the terminal, you may want to add:
+# load in the functions and animations
+source /path/to/bash_loading_animations.sh
+
+# Show a loading animation for the command "foo"
+BLA::start_loading_animation "${BLA_name_of_the_animation[@]}"
+foo
+BLA::stop_loading_animation
+
+# If the command prints some output in the terminal, you may want to add
+# one of the following:
 foo 1> /dev/null # hide standard output
 # or
 foo 2> /dev/null # hide error messages
 # or
 foo &> /dev/null # hide all output
 
-###################################### 5 ######################################
-###################### USE A COMPACT VERSION OF THE CODE ######################
-###############################################################################
-######### Copy one of the paragraphs below at the top of your script, #########
-####################### just after the animations list. #######################
-###############################################################################
-
-# Max width = 80
-trap stop_loading_animation SIGINT ; play_loading_animation_loop() { while \
-true ; do for frame in "${active_loading_animation[@]}" ; do printf "\r%s" \
-"${frame}" ; sleep "${loading_animation_frame_interval}" ; done ; done ; } ; \
-start_loading_animation() { active_loading_animation=( "${@}" ) ; \
-loading_animation_frame_interval="${active_loading_animation[0]}" ; unset \
-"active_loading_animation[0]" ; tput civis ; play_loading_animation_loop & \
-loading_animation_pid="${!}" ; } ; stop_loading_animation() { kill \
-"${loading_animation_pid}" &> /dev/null ; printf "\n" ; tput cnorm ; }
-
-# Each function on a single line
-trap stop_loading_animation SIGINT
-play_loading_animation_loop() { while true ; do for frame in "${active_loading_animation[@]}" ; do printf "\r%s" "${frame}" ; sleep "${loading_animation_frame_interval}" ; done ; done ; }
-start_loading_animation() { active_loading_animation=( "${@}" ) ; loading_animation_frame_interval="${active_loading_animation[0]}" ; unset "active_loading_animation[0]" ; tput civis ; play_loading_animation_loop & loading_animation_pid="${!}" ; }
-stop_loading_animation() { kill "${loading_animation_pid}" &> /dev/null ; printf "\n" ; tput cnorm ; }
-
-# Single line
-trap stop_loading_animation SIGINT ; play_loading_animation_loop() { while true ; do for frame in "${active_loading_animation[@]}" ; do printf "\r%s" "${frame}" ; sleep "${loading_animation_frame_interval}" ; done ; done ; } ; start_loading_animation() { active_loading_animation=( "${@}" ) ; loading_animation_frame_interval="${active_loading_animation[0]}" ; unset "active_loading_animation[0]" ; tput civis ; play_loading_animation_loop & loading_animation_pid="${!}" ; } ; stop_loading_animation() { kill "${loading_animation_pid}" &> /dev/null ; printf "\n" ; tput cnorm ; }
+EXAMPLES


### PR DESCRIPTION
Rather than cut 'n' pasting snippets, this PR will turn the code into a 'library' that can just be loaded. I prefixed the variables and functions with `BLA` so that when they are sourced in, they are very unlikely to conflict with other variables in the script in which BLA is being used. Feel free to reject it if you think it's too far out for you, but this is the way that I am going to use it in my code.